### PR TITLE
Update bootstrap script Python reference

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,24 @@
 #!/bin/sh
-# Simple entry script to launch the Flask API
+# Bootstrap script for running the Flask API inside a container.
+#
+# The container image does not assume any Python environment has
+# been prepared, so this script ensures that a virtual environment
+# exists, installs dependencies and then launches the API using
+# that environment.
 
-# Run the application directly with Python.
-# index.py already exposes the Flask app and runs on port 80 when
-# executed as a script, so no extra arguments are required here.
-python3 ./api/index.py
+set -e
+
+# Use the virtual environment prepared at build time.  The Dockerfile
+# creates it at /venv.  When running locally we create it on the fly.
+VENV_DIR="/venv"
+
+# Create the virtual environment on first run
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/pip" install --no-cache-dir --upgrade pip
+    "$VENV_DIR/bin/pip" install --no-cache-dir -r requirements.txt
+fi
+
+# Activate the environment and execute the API
+. "$VENV_DIR/bin/activate"
+exec "$VENV_DIR/bin/python3" ./api/index.py


### PR DESCRIPTION
## Summary
- use the Python3 executable inside the built virtual environment

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68802a5139688326817e11067340f09b