### PR TITLE
Enable local Redis configuration

### DIFF
--- a/api/config.json
+++ b/api/config.json
@@ -1,4 +1,6 @@
 {
-    "redis_host": "localhost",
-    "redis_port": 6379
+    "redis_host": "127.0.0.1",
+    "redis_port": 6379,
+    "redis_db": 0,
+    "redis_password": null
 }

--- a/api/index.py
+++ b/api/index.py
@@ -1,5 +1,6 @@
 import redis
 import json
+import os
 from flask import Flask, jsonify, request
 from rq import Queue
 from model.job import Language, JobStatus, to_request, to_job, BashJob, PythonJob
@@ -7,9 +8,20 @@ from agent import run_job
 
 app = Flask(__name__)
 
-jobs = []
-redis_client = redis.Redis(port=6379)
+# Load Redis configuration from config.json
+config_path = os.path.join(os.path.dirname(__file__), "config.json")
+with open(config_path, "r") as cfg:
+    config = json.load(cfg)
+
+redis_client = redis.Redis(
+    host=config["redis_host"],
+    port=config["redis_port"],
+    db=config["redis_db"],
+    password=config["redis_password"]
+)
 redis_queue = Queue(connection=redis_client)
+
+jobs = []
 
 # Make sure you don't forget, this needs to work with a worker agent, and needs logging functionality
 


### PR DESCRIPTION
## Summary
- expand `api/config.json` to include host, port, db and password for Redis
- load this configuration in the Flask app and create the Redis client using it
- fix layout of `config.json` to be flat
- read Redis settings directly from config file without defaults

## Testing
- `python3 -m compileall api`


------
https://chatgpt.com/codex/tasks/task_e_68819457321c83269f01094910871e4f